### PR TITLE
Refresh landing page + README after MkDocs/wiki cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 EasyMovie helps you pick movies for movie night. Answer a few questions (genre, rating, runtime) and get a curated random selection from your library. Supports movie set awareness, multiple viewing modes, and playlist generation.
 
-![EasyMovie Showcase View](https://raw.githubusercontent.com/wiki/Rouzax/script.easymovie/images/view-showcase-golden-hour.png)
+![EasyMovie Showcase View](docs/wiki-images/view-showcase-golden-hour.png)
 
 Built for Kodi 21+ (Omega and newer).
 
@@ -58,18 +58,18 @@ EasyMovie presents a quick wizard to filter your movie library, then shows you a
 
 ## Documentation
 
-**Full documentation is available on the [Wiki](https://github.com/Rouzax/script.easymovie/wiki):**
+**Full documentation is available on the [docs site](https://rouzax.github.io/script.easymovie/docs/):**
 
 | Page | Description |
 |------|-------------|
-| [Installation](https://github.com/Rouzax/script.easymovie/wiki/Installation) | Setup and first run |
-| [Filter Wizard](https://github.com/Rouzax/script.easymovie/wiki/Filter-Wizard) | The filter flow explained |
-| [Browse Mode](https://github.com/Rouzax/script.easymovie/wiki/Browse-Mode) | View styles and browsing guide |
-| [Playlist Mode](https://github.com/Rouzax/script.easymovie/wiki/Playlist-Mode) | Movie marathon playlists |
-| [Movie Sets](https://github.com/Rouzax/script.easymovie/wiki/Movie-Sets) | Collection awareness and continuation |
-| [Settings Reference](https://github.com/Rouzax/script.easymovie/wiki/Settings-Reference) | All settings explained |
-| [Advanced Features](https://github.com/Rouzax/script.easymovie/wiki/Advanced-Features) | Clones, debugging, more |
-| [Troubleshooting & FAQ](https://github.com/Rouzax/script.easymovie/wiki/Troubleshooting-and-FAQ) | Common issues |
+| [Installation](https://rouzax.github.io/script.easymovie/docs/installation/) | Setup and first run |
+| [Filter Wizard](https://rouzax.github.io/script.easymovie/docs/filter-wizard/) | The filter flow explained |
+| [Browse Mode](https://rouzax.github.io/script.easymovie/docs/browse-mode/) | View styles and browsing guide |
+| [Playlist Mode](https://rouzax.github.io/script.easymovie/docs/playlist-mode/) | Movie marathon playlists |
+| [Movie Sets](https://rouzax.github.io/script.easymovie/docs/movie-sets/) | Collection awareness and continuation |
+| [Settings Reference](https://rouzax.github.io/script.easymovie/docs/settings-reference/) | All settings explained |
+| [Advanced Features](https://rouzax.github.io/script.easymovie/docs/advanced-features/) | Clones, debugging, more |
+| [Troubleshooting & FAQ](https://rouzax.github.io/script.easymovie/docs/troubleshooting-and-faq/) | Common issues |
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -29,9 +29,10 @@
     <section class="hero">
         <div class="hero-inner">
             <h1>Simplify movie night.</h1>
-            <p>EasyMovie helps you pick movies from your Kodi library. Answer a few quick questions &mdash; genre, rating, runtime &mdash; and get a curated random selection. No more scrolling through hundreds of titles.</p>
+            <p>EasyMovie helps you pick movies from your Kodi library. Answer a few quick questions about genre, rating, and runtime, then get a curated random selection. No more scrolling through hundreds of titles.</p>
             <div class="hero-buttons">
                 <a href="https://github.com/Rouzax/script.easymovie/releases/latest" class="btn btn-primary">Download Latest Release</a>
+                <a href="docs/" class="btn btn-secondary">Documentation</a>
                 <a href="https://github.com/Rouzax/script.easymovie" class="btn btn-secondary">View on GitHub</a>
             </div>
             <div class="hero-screenshot">


### PR DESCRIPTION
Follow-up polish after merging #3.

## Changes

- **README.md:** replace stale `wiki/*` URLs with `rouzax.github.io/script.easymovie/docs/*` equivalents (wiki was disabled at end of #3).
- **README.md:** hero image switches from `raw.githubusercontent.com/wiki/...` to a relative path under `docs/wiki-images/` so it survives the wiki disable.
- **site/index.html:** rewrite hero paragraph `&mdash;` HTML entities to plain prose per project rule.
- **site/index.html:** add a Documentation pill button to the hero CTA row alongside Download and View on GitHub.

## Test plan
- [ ] CI passes
- [ ] After merge, gh-pages deploy refreshes
- [ ] Documentation pill button on the hero is visible and links to /docs/
- [ ] All wiki-table links in the rendered README on github.com point at the docs site